### PR TITLE
Deep freeze notification block + Notification bug resolution

### DIFF
--- a/app/src/main/java/com/example/antigaspi/ExpiryChecker.kt
+++ b/app/src/main/java/com/example/antigaspi/ExpiryChecker.kt
@@ -3,6 +3,7 @@ package com.example.antigaspi
 import android.content.Context
 import android.util.Log
 import java.util.Calendar
+import kotlin.math.ceil
 
 class ExpiryChecker(private val context: Context, private val foodItemAdapter: FoodItemAdapter, private val sharedPreferencesHelper: SharedPreferencesHelper) {
 
@@ -14,32 +15,34 @@ class ExpiryChecker(private val context: Context, private val foodItemAdapter: F
         val currentDate = calendar.time
 
         // Get the threshold value from SharedPreferences
-        val daysBeforeExpiration = sharedPreferencesHelper.getDaysBeforeExpiration()
+        var daysBeforeExpiration = sharedPreferencesHelper.getDaysBeforeExpiration()
+        daysBeforeExpiration += 1
 
-        for (foodItem in foodItems) {
+        for ((index,foodItem) in foodItems.withIndex()) {
             foodItem.expirationDate?.let { expiryDate ->
                 // Calculate the notification date, which is expiration date minus daysBeforeExpiration
                 calendar.time = expiryDate
-                calendar.add(Calendar.MONTH, -1)
                 calendar.add(Calendar.DAY_OF_YEAR, -daysBeforeExpiration)
                 val notificationDate = calendar.time
 
                 val expdate = foodItem.expirationDate
+                Log.d("ExpiryChecker function", "daysBeforeExpiration: $daysBeforeExpiration")
                 Log.d("ExpiryChecker function", "expirationDate: $expdate")
                 Log.d("ExpiryChecker function", "notification date: $notificationDate")
                 Log.d("ExpiryChecker function", "currenDate: $currentDate")
 
                 val diffInMillies = expiryDate.time - currentDate.time
-                val diffInDays = (diffInMillies / (1000 * 60 * 60 * 24)).toInt()
+                val diffInDays = ceil(diffInMillies.toDouble() / (1000 * 60 * 60 * 24)).toInt()
 
                 Log.d("ExpiryChecker function", "comparison: $diffInDays")
 
-                if (diffInDays >= 0) {
+                if (diffInDays in 0..daysBeforeExpiration) {
                     Log.d("ExpiryChecker function", "diffInMillies: $diffInMillies")
                     Log.d("ExpiryChecker function", "diffInDays: $diffInDays")
                     notificationHelper.sendNotification(
                         "Food Expiration Alert",
-                        "Your food item ${foodItem.title} is expiring in $diffInDays days."
+                        "Your food item ${foodItem.title} is expiring in $diffInDays days.",
+                        index
                     )
                 }
             }

--- a/app/src/main/java/com/example/antigaspi/FoodItemDetailActivity.kt
+++ b/app/src/main/java/com/example/antigaspi/FoodItemDetailActivity.kt
@@ -38,7 +38,7 @@ class FoodItemDetailActivity : AppCompatActivity() {
     private lateinit var ocrHelper: OCRHelper
     private lateinit var tvFoodItemTitle: TextView
     private lateinit var tvExpirationDate: TextView
-    private lateinit var tvScannedText: TextView
+//    private lateinit var tvScannedText: TextView
     private lateinit var btnDeepFreeze: Button
     private lateinit var btnSelectDate: Button
     private lateinit var btnEditTitle: ImageButton

--- a/app/src/main/java/com/example/antigaspi/NotificationHelper.kt
+++ b/app/src/main/java/com/example/antigaspi/NotificationHelper.kt
@@ -28,19 +28,22 @@ class NotificationHelper(private val context: Context) {
         }
     }
 
-    fun sendNotification(title: String, message: String) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            // Check for POST_NOTIFICATIONS permission on Android 13 and above
-            if (context.checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
-                // Permission is granted, send the notification
-                sendNotificationWithPermission(title, message)
+    fun sendNotification(title: String, message: String, itemIndex: Int) {
+        val foodItem = SingletonList.theInstance.list[itemIndex]
+        if (!foodItem.isDeepFrozen) { // if deep frozen, pause the notifications
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                // Check for POST_NOTIFICATIONS permission on Android 13 and above
+                if (context.checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+                    // Permission is granted, send the notification
+                    sendNotificationWithPermission(title, message)
+                } else {
+                    // Permission is not granted, handle accordingly
+                    // TODO: Show a dialog to the user explaining why you need the permission and prompt them to grant it
+                }
             } else {
-                // Permission is not granted, handle accordingly
-                // TODO: Show a dialog to the user explaining why you need the permission and prompt them to grant it
+                // For older versions, send the notification without checking for POST_NOTIFICATIONS permission
+                sendNotificationWithPermission(title, message)
             }
-        } else {
-            // For older versions, send the notification without checking for POST_NOTIFICATIONS permission
-            sendNotificationWithPermission(title, message)
         }
     }
 

--- a/app/src/main/java/com/example/antigaspi/SharedPreferencesHelper.kt
+++ b/app/src/main/java/com/example/antigaspi/SharedPreferencesHelper.kt
@@ -24,6 +24,7 @@ class SharedPreferencesHelper(context: Context) {
         return list
     }
     fun getDaysBeforeExpiration(): Int {
-        return prefs.getInt("ExpirationDaysPosition", 3) // Default to 3 days
+        val savedPosition = prefs.getInt("ExpirationDaysPosition", 0)
+        return savedPosition
     }
 }


### PR DESCRIPTION
1. Added the feature of the the deepfreeze notification freeze where you are not notified if your item is deepfrozen.

2. Corrected the issue where the Notification was not according to the days in the settings. Now, you get a notification only <= daysBeforeExpiration